### PR TITLE
Add Datadog Git telemetry configuration

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,12 @@
 FROM golang:1.23-alpine
 
+# Install git to access repository information
+RUN apk add --no-cache git
+
+# Build argument to pass git commit SHA
+ARG DD_GIT_COMMIT_SHA
+ARG DD_GIT_REPOSITORY_URL=https://github.com/olivwalsh/datadog-sci-demo
+
 WORKDIR /usr/src/app
 
 COPY go.mod ./
@@ -8,5 +15,9 @@ RUN go mod download
 COPY *.go ./
 
 RUN go build -o client
+
+# Set Datadog Git environment variables
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
 
 CMD [ "/usr/src/app/client" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,23 @@ services:
   client:
     build:
       context: ./client
+      args:
+        DD_GIT_COMMIT_SHA: ${DD_GIT_COMMIT_SHA:-}
+        DD_GIT_REPOSITORY_URL: https://github.com/olivwalsh/datadog-sci-demo
     environment:
       - SERVER_HOST=server
+      - DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA:-}
+      - DD_GIT_REPOSITORY_URL=https://github.com/olivwalsh/datadog-sci-demo
 
   server:
     build:
       context: ./node-server
+      args:
+        DD_GIT_COMMIT_SHA: ${DD_GIT_COMMIT_SHA:-}
+        DD_GIT_REPOSITORY_URL: https://github.com/olivwalsh/datadog-sci-demo
     environment:
       - DD_AGENT_HOST=datadog-agent
       - DD_VERSION=1.2.6
       - DD_SERVICE=olivia-test
+      - DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA:-}
+      - DD_GIT_REPOSITORY_URL=https://github.com/olivwalsh/datadog-sci-demo

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:16
 
+# Install git to access repository information
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Build arguments to pass git commit SHA and repository URL
+ARG DD_GIT_COMMIT_SHA
+ARG DD_GIT_REPOSITORY_URL=https://github.com/olivwalsh/datadog-sci-demo
+
 # Create app directory
 WORKDIR /usr/src/node-server
 
@@ -14,6 +21,10 @@ RUN npm install
 
 # Bundle app source
 COPY . .
+
+# Set Datadog Git environment variables
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
 
 EXPOSE 8080
 # Not the usual way to start on prod, but it produces stack traces on TS


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9809c9d6-7721-4913-8669-7033c2ad51f6","source":"chat","resourceId":"7e94f4f4-3f47-42b4-8ff7-3382753a19eb","workflowId":"7710ffa3-d3a1-4909-99f9-c99a5b929872","codeChangeId":"7710ffa3-d3a1-4909-99f9-c99a5b929872","sourceType":""} -->
PR by [Bits](https://dd.datad0g.com/code?session_id=9809c9d6-7721-4913-8669-7033c2ad51f6) for chat [7e94f4f4-3f47-42b4-8ff7-3382753a19eb](https://dd.datad0g.com/code/7e94f4f4-3f47-42b4-8ff7-3382753a19eb).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Problem
The `olivia-test` application was not instrumented with SCI Git tags, preventing Code Snippets from appearing in Datadog monitoring.

## Solution
This PR adds Datadog Git telemetry configuration by:

- Adding `DD_GIT_COMMIT_SHA` and `DD_GIT_REPOSITORY_URL` environment variables to both client and server services
- Configuring Dockerfiles to accept git information as build arguments
- Installing git in Docker images to enable repository access
- Updating docker-compose.yml to pass git telemetry values to both services

The commit SHA should be provided at build time using:
```bash
export DD_GIT_COMMIT_SHA=$(git rev-parse HEAD)
```

This enables proper service tagging and Code Snippet visibility in Datadog.