### PR TITLE
Add git telemetry variables to Dockerfiles

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,11 @@
 FROM golang:1.23-alpine
 
+# SCI Git telemetry arguments and environment variables
+ARG DD_GIT_REPOSITORY_URL
+ARG DD_GIT_COMMIT_SHA
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+
 WORKDIR /usr/src/app
 
 COPY go.mod ./

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:16
 
+# SCI Git telemetry arguments and environment variables
+ARG DD_GIT_REPOSITORY_URL
+ARG DD_GIT_COMMIT_SHA
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+
 # Create app directory
 WORKDIR /usr/src/node-server
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"329efce3-62bb-4917-8945-b62c38185492","source":"chat","resourceId":"3183518b-1c48-49e3-b46d-6316b00714c1","workflowId":"245ae8cf-1eb2-4a98-9d36-803d85c41b91","codeChangeId":"245ae8cf-1eb2-4a98-9d36-803d85c41b91","sourceType":"apm-recommendations"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=329efce3-62bb-4917-8945-b62c38185492) for chat [3183518b-1c48-49e3-b46d-6316b00714c1](https://app.datadoghq.com/code/3183518b-1c48-49e3-b46d-6316b00714c1).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary

Fixes missing git telemetry context in Docker containers by adding Datadog git telemetry environment variables to both client and node-server Dockerfiles.

## Problem

The containerized applications were not receiving git repository context (repository URL and commit SHA) needed for proper telemetry tagging, resulting in incomplete or missing source code correlation in monitoring data.

## Solution

Added the following Datadog git telemetry variables to both Dockerfiles:
- `DD_GIT_REPOSITORY_URL` - Repository URL for source code correlation
- `DD_GIT_COMMIT_SHA` - Commit SHA for version tracking

These variables are now properly passed through as build arguments and set as environment variables within the containers, enabling full git context in telemetry data.