### PR TITLE
Add Datadog SCI telemetry tagging configuration

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,1 +1,13 @@
+#!/bin/bash
+
+# Set Git metadata environment variables for Datadog SCI
+export DD_GIT_REPOSITORY_URL="https://github.com/olivwalsh/datadog-sci-demo"
+export DD_GIT_COMMIT_SHA=$(git rev-parse HEAD)
+export DD_TAGS="git.commit.sha:$(git rev-parse HEAD),git.repository_url:https://github.com/olivwalsh/datadog-sci-demo"
+
+# Build and run with SCI metadata
+docker compose build --build-arg DD_GIT_REPOSITORY_URL="$DD_GIT_REPOSITORY_URL" \
+  --build-arg DD_GIT_COMMIT_SHA="$DD_GIT_COMMIT_SHA" \
+  --build-arg DD_TAGS="$DD_TAGS"
+
 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
   olivia-test:
     build:
       context: ./node-server
+      args:
+        - DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+        - DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+        - DD_TAGS=${DD_TAGS}
     environment:
       - DD_AGENT_HOST=datadog-agent
       - DD_SERVICE=olivia-test
+      - DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+      - DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+      - DD_TAGS=${DD_TAGS}

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -1,5 +1,13 @@
 FROM node:16
 
+# Datadog Source Code Integration (SCI) arguments
+ARG DD_GIT_REPOSITORY_URL
+ARG DD_GIT_COMMIT_SHA
+ARG DD_TAGS
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV DD_TAGS=${DD_TAGS}
+
 # Create app directory
 WORKDIR /usr/src/node-server
 
@@ -16,5 +24,5 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-# Not the usual way to start on prod, but it produces stack traces on TS
-CMD [ "npx", "ts-node", "server.ts" ]
+# Enable source maps for better stack traces and SCI integration
+CMD [ "node", "--enable-source-maps", "-r", "ts-node/register", "server.ts" ]

--- a/node-server/tsconfig.json
+++ b/node-server/tsconfig.json
@@ -47,7 +47,7 @@
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
<!-- dd-meta {"pullId":"76981149-14e1-4ab7-af89-5d2feb54e1f4","source":"chat","resourceId":"4ffa8cf9-c4e0-45b7-a21c-bf009612f419","workflowId":"3cf9d45b-80bb-4175-a1b3-d7c34af4a68d","codeChangeId":"3cf9d45b-80bb-4175-a1b3-d7c34af4a68d","sourceType":""} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=76981149-14e1-4ab7-af89-5d2feb54e1f4) for chat [4ffa8cf9-c4e0-45b7-a21c-bf009612f419](https://app.datadoghq.com/code/4ffa8cf9-c4e0-45b7-a21c-bf009612f419).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary

Configures Datadog APM Source Code Integration (SCI) telemetry tagging to enable Git metadata visibility at runtime for better observability and debugging.

## Problem

The application was missing proper configuration to pass Git metadata (commit SHA, repository URL) to the Datadog APM agent, resulting in limited source code context in traces and performance monitoring.

## Solution

Implemented comprehensive SCI setup following Datadog's documentation:

**Build Configuration:**
- Added Git metadata environment variables (`DD_GIT_REPOSITORY_URL`, `DD_GIT_COMMIT_SHA`, `DD_TAGS`) to build process
- Updated `docker-compose.yml` to pass build args and runtime environment variables
- Modified `Dockerfile` to accept and set SCI environment variables

**Source Map Support:**
- Enabled TypeScript source map generation in `tsconfig.json`
- Updated container startup command to use `--enable-source-maps` flag for better stack trace integration

**Build Script:**
- Enhanced `build-and-run.sh` to automatically capture Git metadata and pass to Docker build

## Expected Outcome

- Git commit information will be visible in Datadog APM traces
- Enhanced debugging capabilities with proper source code context
- Improved observability for production issue investigation