### PR TITLE
Add Datadog SCI Git metadata configuration

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,1 +1,8 @@
+#!/bin/bash
+
+# Extract Git metadata for SCI (Source Code Integration)
+export DD_GIT_REPOSITORY_URL=$(git config --get remote.origin.url 2>/dev/null || echo "unknown")
+export DD_GIT_COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+export DD_TAGS="git.commit.sha:${DD_GIT_COMMIT_SHA},git.repository_url:${DD_GIT_REPOSITORY_URL}"
+
 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
   olivia-test:
     build:
       context: ./node-server
+      args:
+        DD_GIT_REPOSITORY_URL: ${DD_GIT_REPOSITORY_URL}
+        DD_GIT_COMMIT_SHA: ${DD_GIT_COMMIT_SHA}
+        DD_TAGS: ${DD_TAGS}
     environment:
       - DD_AGENT_HOST=datadog-agent
       - DD_SERVICE=olivia-test
+      - DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+      - DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+      - DD_TAGS=${DD_TAGS}

--- a/node-server/.dockerignore
+++ b/node-server/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+.git
+!.git/HEAD
+!.git/config
+!.git/refs

--- a/node-server/Dockerfile
+++ b/node-server/Dockerfile
@@ -1,5 +1,13 @@
 FROM node:16
 
+# SCI (Source Code Integration) build arguments for Datadog APM
+ARG DD_GIT_REPOSITORY_URL
+ARG DD_GIT_COMMIT_SHA
+ARG DD_TAGS
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV DD_TAGS=${DD_TAGS}
+
 # Create app directory
 WORKDIR /usr/src/node-server
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2de28dd6-2635-4f1b-bb2a-877b90f721b8","source":"chat","resourceId":"ab56236b-311a-4903-a04f-64e327def09c","workflowId":"dac6d11d-7e67-4206-bb5e-b24aeb620e19","codeChangeId":"dac6d11d-7e67-4206-bb5e-b24aeb620e19","sourceType":""} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=2de28dd6-2635-4f1b-bb2a-877b90f721b8) for chat [ab56236b-311a-4903-a04f-64e327def09c](https://app.datadoghq.com/code/ab56236b-311a-4903-a04f-64e327def09c).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary

Configures Datadog APM Source Code Integration (SCI) to properly capture and pass Git metadata for telemetry tagging.

## Problem

The application was missing Git metadata configuration required for Datadog's Source Code Integration feature. Without this setup, APM traces and metrics wouldn't include critical source code context like commit SHA and repository information, limiting debugging and observability capabilities.

## Solution

- **Enhanced build script**: Added Git metadata extraction to `build-and-run.sh` that captures repository URL, commit SHA, and constructs appropriate tags
- **Updated Docker Compose**: Modified `docker-compose.yml` to pass Git metadata as both build arguments and runtime environment variables
- **Configured Dockerfile**: Added ARG/ENV declarations in `node-server/Dockerfile` to receive and expose Git metadata during build and runtime
- **Created .dockerignore**: Added selective Git file inclusion to allow access to necessary Git metadata while excluding bulk repository data

The changes ensure Git commit information is available throughout the build pipeline and at application runtime, enabling proper source code integration with Datadog APM without modifying application logic or startup behavior.